### PR TITLE
Add 16:10 resolution options. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
                 <div class="mdl-select">
                     <select id="selectResolution">
                         <option value="1280:720">1280x720</option>
+                        <option value="1280:800">1280x800</option>
                         <option value="1920:1080">1920x1080</option>
                         <option value="1920:1200">1920x1200</option>
                         <option value="3840:2160">4K</option>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
                     <select id="selectResolution">
                         <option value="1280:720">1280x720</option>
                         <option value="1920:1080">1920x1080</option>
+                        <option value="1920:1200">1920x1200</option>
                         <option value="3840:2160">4K</option>
                     </select>
                 </div>

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -436,6 +436,12 @@ function updateDefaultBitrate() {
         } else { // 720, 60fps
             $('#bitrateSlider')[0].MaterialSlider.change('10');
         }
+    } else if (res.lastIndexOf("1280:800") === 0) {
+        if (frameRate.lastIndexOf("30", 0) === 0) { // 800, 30fps
+            $('#bitrateSlider')[0].MaterialSlider.change('5');
+        } else { // 800, 60fps
+            $('#bitrateSlider')[0].MaterialSlider.change('10');
+        }
     } else if (res.lastIndexOf("3840:2160", 0) === 0) {
         if (frameRate.lastIndexOf("30", 0) === 0) { // 2160p, 30fps
             $('#bitrateSlider')[0].MaterialSlider.change('40');

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -424,6 +424,12 @@ function updateDefaultBitrate() {
         } else { // 1080p, 60fps
             $('#bitrateSlider')[0].MaterialSlider.change('20');
         }
+    } else if (res.lastIndexOf("1920:1200") === 0) {
+        if (frameRate.lastIndexOf("30", 0) === 0) { // 1200p, 30fps
+            $('#bitrateSlider')[0].MaterialSlider.change('10');
+        } else { // 1200p, 60fps
+            $('#bitrateSlider')[0].MaterialSlider.change('20');
+        }
     } else if (res.lastIndexOf("1280:720") === 0) {
         if (frameRate.lastIndexOf("30", 0) === 0) { // 720, 30fps
             $('#bitrateSlider')[0].MaterialSlider.change('5');


### PR DESCRIPTION
I have a 16:10 laptop, having black bars on the top and bottom of my screen were driving me crazy. I added two 16:10 ratios, choosing 1920x1200 and 1280x800.

I wanted to also add 1440x900, but the RTSP stream would fail to be started if that was chosen. Any ideas why?