### PR TITLE
Several fixes about chrome application window (size and state)

### DIFF
--- a/static/js/background.js
+++ b/static/js/background.js
@@ -1,8 +1,25 @@
-var windowState = 'normal';
+function createWindow(state) {
+    chrome.app.window.create('index.html', {
+        state: state,
+        bounds: {
+            width: 960,
+            height: 540
+        }
+    }, function(window) {
+        // workaround:
+        // state = 'normal' in some cases not work (e.g. starting app from 'chrome://extensions' always open window in fullscreen mode)
+        // it requires manually restoring window state to 'normal'
+        if (state == 'normal') {
+            setTimeout(function() { window.restore(); }, 1000);
+        }
+    });
+}
 
 chrome.app.runtime.onLaunched.addListener(function() {
+    var windowState = 'normal';
+
     if (chrome.storage) {
-        // load stored window settings
+        // load stored window state
         chrome.storage.sync.get('windowState', function(item) {
             windowState = (item && item.windowState)
                 ? item.windowState
@@ -13,33 +30,3 @@ chrome.app.runtime.onLaunched.addListener(function() {
         createWindow(windowState);
     }
 });
-
-function createWindow(state) {
-    chrome.app.window.create('index.html', {
-        state: state,
-        bounds: {
-            width: 960,
-            height: 540
-        }
-    }, function(window) {
-        window.onFullscreened.addListener(onFullscreened);
-        window.onBoundsChanged.addListener(onBoundsChanged);
-    });
-}
-
-
-function onFullscreened() {
-    // save windowState: 'fullscreen'
-    windowState != 'fullscreen' && saveItem('windowState', 'fullscreen', null);
-}
-
-function onBoundsChanged() {
-    // save windowState: 'normal'
-    windowState != 'normal' && saveItem('windowState', 'normal', null);
-}
-
-function saveItem(key, value, callback) {
-    var item = { };
-    item[key] = value;
-    chrome.storage && chrome.storage.sync.set(item, callback);
-}

--- a/static/js/background.js
+++ b/static/js/background.js
@@ -1,8 +1,45 @@
+var windowState = 'normal';
+
 chrome.app.runtime.onLaunched.addListener(function() {
-    chrome.app.window.create('index.html', {
-        state: "normal",
-        bounds: { 
-    		width: 850, height: 500
-    	}
-    });
+    if (chrome.storage) {
+        // load stored window settings
+        chrome.storage.sync.get('windowState', function(item) {
+            windowState = (item && item.windowState)
+                ? item.windowState
+                : windowState;
+            createWindow(windowState);
+        });
+    } else {
+        createWindow(windowState);
+    }
 });
+
+function createWindow(state) {
+    chrome.app.window.create('index.html', {
+        state: state,
+        bounds: {
+            width: 960,
+            height: 540
+        }
+    }, function(window) {
+        window.onFullscreened.addListener(onFullscreened);
+        window.onBoundsChanged.addListener(onBoundsChanged);
+    });
+}
+
+
+function onFullscreened() {
+    // save windowState: 'fullscreen'
+    windowState != 'fullscreen' && saveItem('windowState', 'fullscreen', null);
+}
+
+function onBoundsChanged() {
+    // save windowState: 'normal'
+    windowState != 'normal' && saveItem('windowState', 'normal', null);
+}
+
+function saveItem(key, value, callback) {
+    var item = { };
+    item[key] = value;
+    chrome.storage && chrome.storage.sync.set(item, callback);
+}

--- a/static/js/messages.js
+++ b/static/js/messages.js
@@ -30,6 +30,11 @@ function handleMessage(msg) {
                     });
                 });
                 showApps(api);
+
+                isInGame = false;
+
+                // restore main window from 'fullscreen' to 'normal' mode (if required)
+                (windowState == 'normal') && chrome.app.window.current().restore();
             });
 
         } else if(msg.data === 'Connection Established') {

--- a/static/js/messages.js
+++ b/static/js/messages.js
@@ -30,7 +30,6 @@ function handleMessage(msg) {
                     });
                 });
                 showApps(api);
-                chrome.app.window.current().restore();
             });
 
         } else if(msg.data === 'Connection Established') {


### PR DESCRIPTION
Tested in Chrome 55.0.2883.95 (64-bit) on:
- Windows 10 Pro x64
- macOS Sierra 10.12.2

1. Window state restored with previous saved window state (fullscreen or normal).
Prior to this, the application window does not open in full screen. Now app stored last window state.

2. After closing the game, window restored in previous state.
Prior to this, after closing the game the application window opened in "normal mode", even if user entered in "fullscreen mode". 

3. Application window startup size changed to 16:9 aspect ratio = 960x540.
Cosmetic changes, because major resolution is 1920x1080 = 16:9