### PR TITLE
Handle numpad correctly for macOS client

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -99,6 +99,15 @@ static uint32_t GetTranslatedKeyCode(const pp::KeyboardInputEvent& event) {
             break;
     }
 
+    // We have to handle the ISKEYPAD modifier on macOS, and convert them
+    // to the correct numpad keycodes for Windows.
+    int32_t num = event.GetKeyCode() - 0x30;
+    if ((event.GetModifiers() & PP_INPUTEVENT_MODIFIER_ISKEYPAD) &&
+        num >= 0 && num <= 9) {
+        // Offset with numpad 0's virtual keycode
+        return num + 0x60;
+    }
+
     return event.GetKeyCode();
 }
 


### PR DESCRIPTION
Hello! This PR fixes some of the behaviour reported in #204. On macOS, there is an "ISKEYPAD" modifier that needs to be handled so that the GFE server can receive the correct key codes for Numpad 0-9.

I've only tested this on macOS 10.13 & Windows 10 clients. There is an accompanying PR for `moonlight-common-c` to add the modifier flag. Let me know if this should be handled differently.