### PR TITLE
Make mouse locking optional

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
                             <i class="mdl-icon-toggle__label material-icons">mouse</i>
                         </label>
             <div id="mouseLockTooltip" class="mdl-tooltip" for="mouseLockBtn">
-              Enable mouseLocking (must disable to use tap-to-click on touchpads)
+              Enable mouse locking (must disable to use tap-to-click on touchpads)
             </div>
           </div>
 

--- a/index.html
+++ b/index.html
@@ -80,6 +80,16 @@
           </div>
 
           <div class="nav-menu-parent">
+            <label id="mouseLockBtn" class="mdl-icon-toggle mdl-js-icon-toggle mdl-js-ripple-effect" for="mouseLockEnabledSwitch">
+                            <input type="checkbox" id="mouseLockEnabledSwitch" class="mdl-icon-toggle__input">
+                            <i class="mdl-icon-toggle__label material-icons">mouse</i>
+                        </label>
+            <div id="mouseLockTooltip" class="mdl-tooltip" for="mouseLockBtn">
+              Enable mouseLocking (must disable to use tap-to-click on touchpads)
+            </div>
+          </div>
+
+          <div class="nav-menu-parent">
             <label id="optimizeGamesBtn" class="mdl-icon-toggle mdl-js-icon-toggle mdl-js-ripple-effect" for="optimizeGamesSwitch">
                             <input type="checkbox" id="optimizeGamesSwitch" class="mdl-icon-toggle__input">
                             <i class="mdl-icon-toggle__label material-icons">timeline</i>

--- a/input.cpp
+++ b/input.cpp
@@ -50,6 +50,7 @@ void MoonlightInstance::UnlockMouseOrJustReleaseInput() {
         pp::MouseCursor::SetCursor(this, PP_MOUSECURSOR_TYPE_POINTER);
     }
     m_MouseLocked = false;
+    m_WaitingForAllModifiersUp = false;
 }
 
 void MoonlightInstance::DidLockMouse(int32_t result) {
@@ -263,7 +264,6 @@ bool MoonlightInstance::HandleInputEvent(const pp::InputEvent& event) {
             // Check if all modifiers are up now
             if (m_WaitingForAllModifiersUp && modifiers == 0) {
                 UnlockMouseOrJustReleaseInput();
-                m_WaitingForAllModifiersUp = false;
             }
             
             LiSendKeyboardEvent(KEY_PREFIX << 8 | keyCode,

--- a/main.cpp
+++ b/main.cpp
@@ -201,9 +201,9 @@ void MoonlightInstance::HandleStartStream(int32_t callbackId, pp::VarArray args)
     std::string bitrate = args.Get(4).AsString();
     std::string rikey = args.Get(5).AsString();
     std::string rikeyid = args.Get(6).AsString();
-    std::string appversion = args.Get(7).AsString();
-    std::string gfeversion = args.Get(8).AsString();
-    //std::string mouse_lock = args.Get(9).AsString();
+    std::string mouse_lock = args.Get(7).AsString();
+    std::string appversion = args.Get(8).AsString();
+    std::string gfeversion = args.Get(9).AsString();
     
     pp::Var response("Setting stream width to: " + width);
     PostMessage(response);

--- a/main.cpp
+++ b/main.cpp
@@ -40,7 +40,7 @@ void MoonlightInstance::OnConnectionStarted(uint32_t unused) {
     PostMessage(response);
     
     // Start receiving input events
-    RequestInputEvents(PP_INPUTEVENT_CLASS_MOUSE | PP_INPUTEVENT_CLASS_WHEEL | PP_INPUTEVENT_CLASS_TOUCH);
+    RequestInputEvents(PP_INPUTEVENT_CLASS_MOUSE | PP_INPUTEVENT_CLASS_WHEEL | PP_INPUTEVENT_CLASS_TOUCH | PP_INPUTEVENT_CLASS_IME);
     
     // Filtering is suboptimal but it ensures that we can pass keyboard events
     // to the browser when mouse lock is disabled. This is neccessary for Esc
@@ -56,7 +56,8 @@ void MoonlightInstance::OnConnectionStopped(uint32_t error) {
     ClearInputEventRequest(PP_INPUTEVENT_CLASS_MOUSE |
                            PP_INPUTEVENT_CLASS_WHEEL |
                            PP_INPUTEVENT_CLASS_KEYBOARD |
-                           PP_INPUTEVENT_CLASS_TOUCH);
+                           PP_INPUTEVENT_CLASS_TOUCH |
+			   PP_INPUTEVENT_CLASS_IME);
     
     // Unlock the mouse
     UnlockMouse();
@@ -202,6 +203,7 @@ void MoonlightInstance::HandleStartStream(int32_t callbackId, pp::VarArray args)
     std::string rikeyid = args.Get(6).AsString();
     std::string appversion = args.Get(7).AsString();
     std::string gfeversion = args.Get(8).AsString();
+    //std::string mouse_lock = args.Get(9).AsString();
     
     pp::Var response("Setting stream width to: " + width);
     PostMessage(response);
@@ -219,8 +221,10 @@ void MoonlightInstance::HandleStartStream(int32_t callbackId, pp::VarArray args)
     PostMessage(response);
     response = ("Setting appversion to: " + appversion);
     PostMessage(response);
-    response = ("Setting gfeversion to: " + gfeversion);
+    response = ("Setting gfeversion... to: " + gfeversion);
     PostMessage(response);
+    // response = ("Setting mouse lock to: " + mouse_lock);
+    // PostMessage(response);
     
     // Populate the stream configuration
     LiInitializeStreamConfiguration(&m_StreamConfig);
@@ -245,6 +249,7 @@ void MoonlightInstance::HandleStartStream(int32_t callbackId, pp::VarArray args)
     m_Host = host;
     m_AppVersion = appversion;
     m_GfeVersion = gfeversion;
+    m_MouseLockingFeatureEnabled = 1; //stoi(mouse_lock);
     
     // Initialize the rendering surface before starting the connection
     if (InitializeRenderingSurface(m_StreamConfig.width, m_StreamConfig.height)) {

--- a/main.cpp
+++ b/main.cpp
@@ -40,7 +40,7 @@ void MoonlightInstance::OnConnectionStarted(uint32_t unused) {
     PostMessage(response);
     
     // Start receiving input events
-    RequestInputEvents(PP_INPUTEVENT_CLASS_MOUSE | PP_INPUTEVENT_CLASS_WHEEL | PP_INPUTEVENT_CLASS_TOUCH | PP_INPUTEVENT_CLASS_IME);
+    RequestInputEvents(PP_INPUTEVENT_CLASS_MOUSE | PP_INPUTEVENT_CLASS_WHEEL | PP_INPUTEVENT_CLASS_TOUCH);
     
     // Filtering is suboptimal but it ensures that we can pass keyboard events
     // to the browser when mouse lock is disabled. This is neccessary for Esc
@@ -56,8 +56,7 @@ void MoonlightInstance::OnConnectionStopped(uint32_t error) {
     ClearInputEventRequest(PP_INPUTEVENT_CLASS_MOUSE |
                            PP_INPUTEVENT_CLASS_WHEEL |
                            PP_INPUTEVENT_CLASS_KEYBOARD |
-                           PP_INPUTEVENT_CLASS_TOUCH |
-			   PP_INPUTEVENT_CLASS_IME);
+                           PP_INPUTEVENT_CLASS_TOUCH);
     
     // Unlock the mouse
     UnlockMouse();
@@ -221,7 +220,7 @@ void MoonlightInstance::HandleStartStream(int32_t callbackId, pp::VarArray args)
     PostMessage(response);
     response = ("Setting appversion to: " + appversion);
     PostMessage(response);
-    response = ("Setting gfeversion... to: " + gfeversion);
+    response = ("Setting gfeversion to: " + gfeversion);
     PostMessage(response);
     response = ("Setting mouse lock to: " + mouse_lock);
     PostMessage(response);

--- a/main.cpp
+++ b/main.cpp
@@ -59,7 +59,7 @@ void MoonlightInstance::OnConnectionStopped(uint32_t error) {
                            PP_INPUTEVENT_CLASS_TOUCH);
     
     // Unlock the mouse
-    UnlockMouse();
+    UnlockMouseOrJustReleaseInput();
     
     // Notify the JS code that the stream has ended
     pp::Var response(std::string(MSG_STREAM_TERMINATED) + std::to_string((int)error));

--- a/main.cpp
+++ b/main.cpp
@@ -223,8 +223,8 @@ void MoonlightInstance::HandleStartStream(int32_t callbackId, pp::VarArray args)
     PostMessage(response);
     response = ("Setting gfeversion... to: " + gfeversion);
     PostMessage(response);
-    // response = ("Setting mouse lock to: " + mouse_lock);
-    // PostMessage(response);
+    response = ("Setting mouse lock to: " + mouse_lock);
+    PostMessage(response);
     
     // Populate the stream configuration
     LiInitializeStreamConfiguration(&m_StreamConfig);
@@ -249,7 +249,7 @@ void MoonlightInstance::HandleStartStream(int32_t callbackId, pp::VarArray args)
     m_Host = host;
     m_AppVersion = appversion;
     m_GfeVersion = gfeversion;
-    m_MouseLockingFeatureEnabled = 1; //stoi(mouse_lock);
+    m_MouseLockingFeatureEnabled = stoi(mouse_lock);
     
     // Initialize the rendering surface before starting the connection
     if (InitializeRenderingSurface(m_StreamConfig.width, m_StreamConfig.height)) {

--- a/moonlight.hpp
+++ b/moonlight.hpp
@@ -66,6 +66,8 @@ class MoonlightInstance : public pp::Instance, public pp::MouseLock {
             m_AccumulatedTicks(0),
             m_MouseDeltaX(0),
             m_MouseDeltaY(0),
+            m_MousePositionX(0),
+            m_MousePositionY(0),
             m_LastTouchUpTime(0),
             m_HttpThreadPoolSequence(0) {
             // This function MUST be used otherwise sockets don't work (nacl_io_init() doesn't work!)            
@@ -170,6 +172,7 @@ class MoonlightInstance : public pp::Instance, public pp::MouseLock {
         std::string m_Host;
         std::string m_AppVersion;
         std::string m_GfeVersion;
+        bool m_MouseLockingFeatureEnabled;
         STREAM_CONFIGURATION m_StreamConfig;
         bool m_Running;
         
@@ -199,6 +202,7 @@ class MoonlightInstance : public pp::Instance, public pp::MouseLock {
         bool m_WaitingForAllModifiersUp;
         float m_AccumulatedTicks;
         int32_t m_MouseDeltaX, m_MouseDeltaY;
+        int32_t m_MousePositionX, m_MousePositionY;
         PP_TimeTicks m_LastTouchUpTime;
         pp::FloatPoint m_LastTouchUpPoint;
     

--- a/moonlight.hpp
+++ b/moonlight.hpp
@@ -111,6 +111,8 @@ class MoonlightInstance : public pp::Instance, public pp::MouseLock {
         
         void MouseLockLost();
         void DidLockMouse(int32_t result);
+        void LockMouseOrJustCaptureInput();
+        void UnlockMouseOrJustReleaseInput();
         
         void OnConnectionStopped(uint32_t unused);
         void OnConnectionStarted(uint32_t error);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -297,7 +297,6 @@ main {
     margin: auto !important;
     padding: 0 !important;
     border: none !important;
-    cursor: none;
 }
 .current-game {
     outline: auto #8BC34A;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -297,6 +297,7 @@ main {
     margin: auto !important;
     padding: 0 !important;
     border: none !important;
+    cursor: none;
 }
 .current-game {
     outline: auto #8BC34A;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -687,7 +687,7 @@ function startGame(host, appID) {
       var streamHeight = $('#selectResolution').data('value').split(':')[1];
       // we told the user it was in Mbps. We're dirty liars and use Kbps behind their back.
       var bitrate = parseInt($("#bitrateSlider").val()) * 1000;
-      var mouse_lock_enabled = $("#mouseLockEnabledSwitch").parent().hasClass('is-checked') ? 1 : 0;
+      var mouse_lock_enabled = $("#mouseLockEnabledSwitch").parent().hasClass('is-checked') ? "1" : "0";
       console.log('%c[index.js, startGame]', 'color:green;', 'startRequest:' + host.address + ":" + streamWidth + ":" + streamHeight + ":" + frameRate + ":" + bitrate + ":" + optimize + ":" + mouse_lock_enabled);
 
       var rikey = generateRemoteInputKey();

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -711,7 +711,7 @@ function startGame(host, appID) {
           }
 
           sendMessage('startRequest', [host.address, streamWidth, streamHeight, frameRate,
-            bitrate.toString(), rikey, rikeyid.toString(), host.appVersion, host.gfeVersion //, mouse_lock_enabled
+            bitrate.toString(), rikey, rikeyid.toString(), mouse_lock_enabled, host.appVersion, host.gfeVersion
           ]);
         }, function(failedResumeApp) {
           console.eror('%c[index.js, startGame]', 'color:green;', 'Failed to resume the app! Returned error was' + failedResumeApp);
@@ -721,7 +721,6 @@ function startGame(host, appID) {
       }
 
       var remote_audio_enabled = $("#remoteAudioEnabledSwitch").parent().hasClass('is-checked') ? 1 : 0;
-      var mouse_lock_enabled = $("#mouseLockEnabledSwitch").parent().hasClass('is-checked') ? 1 : 0;
 
       host.launchApp(appID,
         streamWidth + "x" + streamHeight + "x" + frameRate,
@@ -749,7 +748,7 @@ function startGame(host, appID) {
         }
 
         sendMessage('startRequest', [host.address, streamWidth, streamHeight, frameRate,
-          bitrate.toString(), rikey, rikeyid.toString(), host.appVersion// , host.gfeVersion, mouse_lock_enabled
+          bitrate.toString(), rikey, rikeyid.toString(), mouse_lock_enabled, host.appVersion
         ]);
       }, function(failedLaunchApp) {
         console.error('%c[index.js, launchApp]', 'color: green;', 'Failed to launch app width id: ' + appID + '\nReturned error was: ' + failedLaunchApp);

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -978,7 +978,7 @@ function onWindowLoad() {
     // Load stored mouse lock prefs
     chrome.storage.sync.get('mouseLock', function(previousValue) {
       if (previousValue.mouseLock == null) {
-        document.querySelector('#mouseLockBtn').MaterialIconToggle.uncheck();
+        document.querySelector('#mouseLockBtn').MaterialIconToggle.check();
       } else if (previousValue.mouseLock == false) {
         document.querySelector('#mouseLockBtn').MaterialIconToggle.uncheck();
       } else {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -15,6 +15,7 @@ function attachListeners() {
   $('#bitrateSlider').on('input', updateBitrateField); // input occurs every notch you slide
   //$('#bitrateSlider').on('change', saveBitrate); //FIXME: it seems not working
   $("#remoteAudioEnabledSwitch").on('click', saveRemoteAudio);
+  $("#mouseLockEnabledSwitch").on('click', saveMouseLock);
   $('#optimizeGamesSwitch').on('click', saveOptimize);
   $('#addHostCell').on('click', addHost);
   $('#backIcon').on('click', showHostsAndSettingsMode);
@@ -597,6 +598,7 @@ function showHostsAndSettingsMode() {
   $("#main-navigation").show();
   $(".nav-menu-parent").show();
   $("#externalAudioBtn").show();
+  $("#mouseLockBtn").show();
   $("#main-content").children().not("#listener, #loadingSpinner, #naclSpinner").show();
   $('#game-grid').hide();
   $('#backIcon').hide();
@@ -615,6 +617,7 @@ function showAppsMode() {
   $("#streamSettings").hide();
   $(".nav-menu-parent").hide();
   $("#externalAudioBtn").hide();
+  $("#mouseLockBtn").hide();
   $("#host-grid").hide();
   $("#settings").hide();
   $("#main-content").removeClass("fullscreen");
@@ -684,7 +687,8 @@ function startGame(host, appID) {
       var streamHeight = $('#selectResolution').data('value').split(':')[1];
       // we told the user it was in Mbps. We're dirty liars and use Kbps behind their back.
       var bitrate = parseInt($("#bitrateSlider").val()) * 1000;
-      console.log('%c[index.js, startGame]', 'color:green;', 'startRequest:' + host.address + ":" + streamWidth + ":" + streamHeight + ":" + frameRate + ":" + bitrate + ":" + optimize);
+      var mouse_lock_enabled = $("#mouseLockEnabledSwitch").parent().hasClass('is-checked') ? 1 : 0;
+      console.log('%c[index.js, startGame]', 'color:green;', 'startRequest:' + host.address + ":" + streamWidth + ":" + streamHeight + ":" + frameRate + ":" + bitrate + ":" + optimize + ":" + mouse_lock_enabled);
 
       var rikey = generateRemoteInputKey();
       var rikeyid = generateRemoteInputKeyId();
@@ -707,7 +711,7 @@ function startGame(host, appID) {
           }
 
           sendMessage('startRequest', [host.address, streamWidth, streamHeight, frameRate,
-            bitrate.toString(), rikey, rikeyid.toString(), host.appVersion, host.gfeVersion
+            bitrate.toString(), rikey, rikeyid.toString(), host.appVersion, host.gfeVersion //, mouse_lock_enabled
           ]);
         }, function(failedResumeApp) {
           console.eror('%c[index.js, startGame]', 'color:green;', 'Failed to resume the app! Returned error was' + failedResumeApp);
@@ -717,6 +721,7 @@ function startGame(host, appID) {
       }
 
       var remote_audio_enabled = $("#remoteAudioEnabledSwitch").parent().hasClass('is-checked') ? 1 : 0;
+      var mouse_lock_enabled = $("#mouseLockEnabledSwitch").parent().hasClass('is-checked') ? 1 : 0;
 
       host.launchApp(appID,
         streamWidth + "x" + streamHeight + "x" + frameRate,
@@ -744,7 +749,7 @@ function startGame(host, appID) {
         }
 
         sendMessage('startRequest', [host.address, streamWidth, streamHeight, frameRate,
-          bitrate.toString(), rikey, rikeyid.toString(), host.appVersion
+          bitrate.toString(), rikey, rikeyid.toString(), host.appVersion// , host.gfeVersion, mouse_lock_enabled
         ]);
       }, function(failedLaunchApp) {
         console.error('%c[index.js, launchApp]', 'color: green;', 'Failed to launch app width id: ' + appID + '\nReturned error was: ' + failedLaunchApp);
@@ -901,6 +906,16 @@ function saveRemoteAudio() {
   }, 100);
 }
 
+function saveMouseLock() {
+  // MaterialDesignLight uses the mouseup trigger, so we give it some time to change the class name before
+  // checking the new state
+  setTimeout(function() {
+    var mouseLockState = $("#mouseLockEnabledSwitch").parent().hasClass('is-checked');
+    console.log('%c[index.js, saveMouseLock]', 'color: green;', 'Saving mouse lock state : ' + mouseLockState);
+    storeData('mouseLock', mouseLockState, null);
+  }, 100);
+}
+
 function updateDefaultBitrate() {
   var res = $('#selectResolution').data('value');
   var frameRate = $('#selectFramerate').data('value').toString();
@@ -958,6 +973,17 @@ function onWindowLoad() {
         document.querySelector('#externalAudioBtn').MaterialIconToggle.uncheck();
       } else {
         document.querySelector('#externalAudioBtn').MaterialIconToggle.check();
+      }
+    });
+
+    // Load stored mouse lock prefs
+    chrome.storage.sync.get('mouseLock', function(previousValue) {
+      if (previousValue.mouseLock == null) {
+        document.querySelector('#mouseLockBtn').MaterialIconToggle.uncheck();
+      } else if (previousValue.mouseLock == false) {
+        document.querySelector('#mouseLockBtn').MaterialIconToggle.uncheck();
+      } else {
+        document.querySelector('#mouseLockBtn').MaterialIconToggle.check();
       }
     });
 


### PR DESCRIPTION
# Make mouse locking optional

Mouse-locking breaks tap-to-click functionality on a chromebook's touchpad (see https://bugs.chromium.org/p/chromium/issues/detail?id=1335564). My primary use-case are point-and-click games which do not rely on infinite mouse movement but only on absolute mouse position on-screen. Hence I would like to make mouse-locking optional in moonlight.

Changes proposed in this pull request:
- Add 'Mouse locking' checkbox in the main moonlight window
- Pass the 'mouse locking' state to the NaCl moonlight component
- This is then accessed in input processing code (input.cpp) to either use the old behaviour or not lock the mouse pointer anymore
- In the new behaviour all input events that are received are processed irrespective of mouse-locking and instead of relative mouse movements, absolute mouse position is sent instead

@moonlight-stream
