### PR TITLE
Resolve various issues

### DIFF
--- a/connectionlistener.cpp
+++ b/connectionlistener.cpp
@@ -56,4 +56,5 @@ CONNECTION_LISTENER_CALLBACKS MoonlightInstance::s_ClCallbacks = {
     .connectionStarted = MoonlightInstance::ClConnectionStarted,
     .connectionTerminated = MoonlightInstance::ClConnectionTerminated,
     .logMessage = MoonlightInstance::ClLogMessage,
+    .rumble = MoonlightInstance::ClControllerRumble,
 };

--- a/gamepad.cpp
+++ b/gamepad.cpp
@@ -4,6 +4,8 @@
 
 #include <Limelight.h>
 
+#include <sstream>
+
 static const unsigned short k_StandardGamepadButtonMapping[] = {
     A_FLAG, B_FLAG, X_FLAG, Y_FLAG,
     LB_FLAG, RB_FLAG,
@@ -126,4 +128,15 @@ void MoonlightInstance::PollGamepads() {
                                    leftStickX, leftStickY, rightStickX, rightStickY);
         controllerIndex++;
     }
+}
+
+void MoonlightInstance::ClControllerRumble(unsigned short controllerNumber, unsigned short lowFreqMotor, unsigned short highFreqMotor)
+{
+    const float weakMagnitude = static_cast<float>(highFreqMotor) / static_cast<float>(UINT16_MAX);
+    const float strongMagnitude = static_cast<float>(lowFreqMotor) / static_cast<float>(UINT16_MAX);
+
+    std::ostringstream ss;
+    ss << controllerNumber << "," << weakMagnitude << "," << strongMagnitude;
+    pp::Var response(std::string("controllerRumble: ") + ss.str());
+    g_Instance->PostMessage(response);
 }

--- a/gamepad.cpp
+++ b/gamepad.cpp
@@ -132,6 +132,14 @@ void MoonlightInstance::PollGamepads() {
 
 void MoonlightInstance::ClControllerRumble(unsigned short controllerNumber, unsigned short lowFreqMotor, unsigned short highFreqMotor)
 {
+    PP_GamepadsSampleData gamepadData;
+    g_Instance->m_GamepadApi->Sample(g_Instance->pp_instance(), &gamepadData);
+
+    // We must determine which gamepads are connected before sending rumble events.
+    const unsigned short activeGamepadMask = static_cast<unsigned short>(GetActiveGamepadMask(gamepadData));
+    if ((activeGamepadMask & (1 << controllerNumber)) == 0)
+        return;
+
     const float weakMagnitude = static_cast<float>(highFreqMotor) / static_cast<float>(UINT16_MAX);
     const float strongMagnitude = static_cast<float>(lowFreqMotor) / static_cast<float>(UINT16_MAX);
 

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,8 @@
         "pointerLock",
         "system.network",
         "fullscreen",
-        "power", {
+        "power",
+        "overrideEscFullscreen", {
         "socket": [
             "tcp-connect",
             "resolve-host",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Moonlight Game Streaming",
     "short_name": "Moonlight",
-    "version": "0.10.21",
+    "version": "0.10.22",
     "description": "Open-source client for NVIDIA GameStream",
     "icons": {
         "128": "icons/icon128.png",

--- a/manifest.json
+++ b/manifest.json
@@ -26,8 +26,7 @@
         "pointerLock",
         "system.network",
         "fullscreen",
-        "power",
-        "overrideEscFullscreen", {
+        "power", {
         "socket": [
             "tcp-connect",
             "resolve-host",

--- a/moonlight.hpp
+++ b/moonlight.hpp
@@ -166,6 +166,9 @@ class MoonlightInstance : public pp::Instance, public pp::MouseLock {
         void NvHTTPInit(int32_t callbackId, pp::VarArray args);
         void NvHTTPRequest(int32_t, int32_t callbackId, pp::VarArray args);
         
+    public:
+        const PPB_Gamepad* m_GamepadApi;
+        
     private:
         static CONNECTION_LISTENER_CALLBACKS s_ClCallbacks;
         static DECODER_RENDERER_CALLBACKS s_DrCallbacks;
@@ -197,7 +200,6 @@ class MoonlightInstance : public pp::Instance, public pp::MouseLock {
         pp::Audio m_AudioPlayer;
         
         double m_LastPadTimestamps[4];
-        const PPB_Gamepad* m_GamepadApi;
         pp::CompletionCallbackFactory<MoonlightInstance> m_CallbackFactory;
         bool m_MouseLocked;
         bool m_WaitingForAllModifiersUp;

--- a/moonlight.hpp
+++ b/moonlight.hpp
@@ -137,6 +137,7 @@ class MoonlightInstance : public pp::Instance, public pp::MouseLock {
         static void ClDisplayMessage(const char* message);
         static void ClDisplayTransientMessage(const char* message);
         static void ClLogMessage(const char* format, ...);
+        static void ClControllerRumble(unsigned short controllerNumber, unsigned short lowFreqMotor, unsigned short highFreqMotor);
         
         static Shader CreateProgram(const char* vertexShader, const char* fragmentShader);
         static void CreateShader(GLuint program, GLenum type, const char* source, int size);

--- a/static/js/background.js
+++ b/static/js/background.js
@@ -1,19 +1,8 @@
+const windowId = "1337";
 function createWindow(state) {
   chrome.app.window.create('index.html', {
-    state: state,
-    bounds: {
-      width: 960,
-      height: 540
-    }
-  }, function(window) {
-    // workaround:
-    // state = 'normal' in some cases not work (e.g. starting app from 'chrome://extensions' always open window in fullscreen mode)
-    // it requires manually restoring window state to 'normal'
-    if (state == 'normal') {
-      setTimeout(function() {
-        window.restore();
-      }, 1000);
-    }
+    state: "normal",
+    id: windowId,
   });
 }
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -718,6 +718,7 @@ function playGameMode() {
   $("#main-navigation").hide();
   $("#main-content").children().not("#listener, #loadingSpinner").hide();
   $("#main-content").addClass("fullscreen");
+  $("#listener").addClass("fullscreen");
 
   fullscreenNaclModule();
   $('#loadingSpinner').css('display', 'inline-block');

--- a/static/js/messages.js
+++ b/static/js/messages.js
@@ -81,6 +81,18 @@ function handleMessage(msg) {
       snackbarLogLong(msg.data.replace('DialogMsg: ', ''));
     } else if (msg.data === 'displayVideo') {
       $("#listener").addClass("fullscreen");
+    } else if (msg.data.indexOf('controllerRumble: ' ) === 0) {
+      const eventData = msg.data.split( ' ' )[1].split(',');
+      const gamepadIdx = parseInt(eventData[0]);
+      const weakMagnitude = parseFloat(eventData[1]);
+      const strongMagnitude = parseFloat(eventData[2]);
+      console.log("Playing rumble on gamepad " + gamepadIdx + " with weakMagnitude " + weakMagnitude + " and strongMagnitude " + strongMagnitude);
+      navigator.getGamepads()[gamepadIdx].vibrationActuator.playEffect('dual-rumble', {
+        startDelay: 0,
+        duration: 5000, // Moonlight should be sending another rumble event when stopping.
+        weakMagnitude: weakMagnitude,
+        strongMagnitude: strongMagnitude,
+      });
     }
   }
 }


### PR DESCRIPTION
Fixes #521
Potential fixes for #519 #522 #523

Changes proposed in this pull request:
- Remove explicit fullscreen handling in the app and let ChromeOS manage fullscreen state. Users will need to autohide the shelf to get the full immersive experience in tablet mode; the fullscreen button toggle works as expected in laptop mode.
-- Moonlight window now has a windowId associated with it so ChromeOS can remember window size and position for the app.
- The "listener" div now gets .fullscreen style applied to it. This seems to resolve the stream just displaying a black screen.
- Pepper SDK and NaCl in general is EOL for Chrome, although still supported for Chrome Apps. This means that the Pepper Gamepad API was never updated with rumble support so in order to add rumble support, rumble messages from Gamestream have to be forwarded to JavaScript and handled with gamepad.vibrationActuator.playEffect().
-- Side note, Chrome limits the duration of playEffect to 5 seconds and requesting more than that causes the vibration request to be rejected.

@moonlight-stream
